### PR TITLE
Add url attribute to social class

### DIFF
--- a/lib/App/LinkSite/Social.pm
+++ b/lib/App/LinkSite/Social.pm
@@ -8,6 +8,7 @@ class App::LinkSite::Social {
 
   field $service :param;
   field $handle :param;
+  field $url :param; # P4e3f
 
   # TODO: This needs to be a class field.
   field $urls = {
@@ -77,21 +78,24 @@ class App::LinkSite::Social {
 
   method service { return $service }
   method handle { return $handle }
+  method url { return $url } # P4e3f
 
   method mk_social_link {
-    my $url;
+    my $url = $self->url; # P3dc4
 
-    if (exists $urls->{$service}) {
-      $url = $urls->{$service}{url};
-    } else {
-      warn('Unknown social service: ', $service);
-      return;
-    }
+    if (!$url) { # P3dc4
+      if (exists $urls->{$service}) {
+        $url = $urls->{$service}{url};
+      } else {
+        warn('Unknown social service: ', $service);
+        return;
+      }
 
-    if ($url =~ /XXXX/) {
-      $url =~ s/XXXX/$handle/g;
-    } else {
-      $url .= $handle;
+      if ($url =~ /XXXX/) {
+        $url =~ s/XXXX/$handle/g;
+      } else {
+        $url .= $handle;
+      }
     }
 
     return $url;

--- a/links.json
+++ b/links.json
@@ -24,7 +24,8 @@
   }, {
     "service": "reddit"
   }, {
-    "service": "mastodon"
+    "service": "mastodon",
+    "url": "https://mastodon.social/@davorg"
   }, {
     "service": "threads"
   }, {


### PR DESCRIPTION
Fixes #1

Add an optional `url` attribute to the `App::LinkSite::Social` class and update methods to use it when set.

* **lib/App/LinkSite/Social.pm**
  - Add a new optional `url` attribute as a field with `:param`.
  - Update the `mk_social_link` method to check for the `url` attribute.
  - Use the `url` attribute directly if it is set in the `mk_social_link` method.
  - Add a `url` method to return the `url` attribute.

* **links.json**
  - Add a `url` attribute to the Mastodon social network entry.
  - Set the `url` attribute to a specific Mastodon instance URL.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg-cpan/app-linksite/issues/1?shareId=928189dd-7836-49c6-b9a6-ef98fec3f7c7).